### PR TITLE
[MayoneJY] week10

### DIFF
--- a/week10/16234_인구 이동/MayoneJY.java
+++ b/week10/16234_인구 이동/MayoneJY.java
@@ -1,0 +1,130 @@
+
+import java.util.*;
+import java.io.*;
+
+public class MayoneJY {
+    static int N, L, R;
+    static Info[][] infos;
+    static int[] dx = {1, 0, -1, 0};
+    static int[] dy = {0, 1, 0, -1};
+
+    static class Info{
+        int A;
+        boolean check;
+        Info(int A, boolean check){
+            this.A = A;
+            this.check = check;
+        }
+        Info(int A){
+            this.A = A;
+            this.check = false;
+        }
+        void t(){
+            check = true;
+        }
+        void f(){
+            check = false;
+        }
+    }
+    static class Node{
+        int y, x;
+        Node(int y, int x){
+            this.y = y;
+            this.x = x;
+        }
+    }
+    static class BFSNode{
+        int cal;
+        ArrayDeque<Node> q;
+        BFSNode(int cal, ArrayDeque<Node> q){
+            this.cal = cal;
+            this.q = q;
+        }
+    }
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        L = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+        infos = new Info[N][N];
+        for(int i = 0; i < N; i++){
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0; j < N; j++){
+                infos[i][j] = new Info(Integer.parseInt(st.nextToken()));
+            }
+        }
+        System.out.println(bfs());
+
+    }
+
+    static int bfs(){
+        int count = 0;
+        while(true){
+            List<BFSNode> list = new ArrayList<>();
+            boolean check = false;
+            for(int n = 0; n < N; n++){
+                for(int m = 0; m < N; m++){
+                    if(!infos[n][m].check){
+                        ArrayDeque<Node> q = new ArrayDeque<>();
+                        int ANum = 0;
+                        int nodeNum = 1;
+                        ArrayDeque<Node> tq = new ArrayDeque<>();
+
+                        q.add(new Node(n, m));
+                        infos[n][m].t();
+                        ANum = infos[n][m].A;
+                        tq.add(new Node(n, m));
+                        if(q.isEmpty())
+                            break;
+
+                        while (!q.isEmpty()) {
+                            Node now = q.poll();
+                            for(int i = 0; i < 4; i++){
+                                Node next = new Node(now.y + dy[i], now.x + dx[i]);
+                                if(next.y >= 0 && next.x >= 0 && next.y < N && next.x < N){
+                                    int temp = Math.abs(infos[now.y][now.x].A - infos[next.y][next.x].A);
+                                    if(!infos[next.y][next.x].check && 
+                                        temp >= L && temp <= R){
+                                        check = true;
+                                        ANum += infos[next.y][next.x].A;
+                                        infos[next.y][next.x].t();
+                                        nodeNum++;
+                                        q.add(next);
+                                        tq.add(next);
+                                    }
+                                }
+                            }
+                        }
+                        if(nodeNum != 1){
+                            int cal = ANum / nodeNum;
+                            list.add(new BFSNode(cal, tq));
+                        }
+                    }
+                }
+            }
+
+            for(int i = 0; i < list.size(); i++){
+                BFSNode node = list.get(i);
+                while (!node.q.isEmpty()) {
+                    Node now = node.q.poll();
+                    infos[now.y][now.x].A = node.cal;
+                }
+            }
+            for(int i = 0; i < N; i++){
+                for(int j = 0; j < N; j++){
+                    infos[i][j].f();
+                    // System.out.printf("%d ", infos[i][j].A);
+                }
+                // System.out.println();
+            }
+            if (!check) {
+                break;
+            }
+            else{
+                count++;
+            }
+        }
+        return count;
+    }
+}

--- a/week10/1806_부분합/MayoneJY.java
+++ b/week10/1806_부분합/MayoneJY.java
@@ -1,0 +1,38 @@
+
+import java.io.*;
+import java.util.*;
+
+public class MayoneJY {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int S = Integer.parseInt(st.nextToken());
+
+        int[] map = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for(int n = 0; n < N; n++){
+            map[n] = Integer.parseInt(st.nextToken());
+        }
+
+        int ans = Integer.MAX_VALUE;
+        int count = 0;
+        int temp = 0;
+        int tempN = 0;
+        outBreak:
+        for(int n = 0; n < N; n++){
+
+            while(temp < S){
+                if(tempN >= N) break outBreak;
+                temp += map[tempN++];
+                count++;
+            }
+            ans = Math.min(ans, count);
+            count--;
+            temp -= map[n];
+        }
+
+        System.out.println(ans == Integer.MAX_VALUE ? 0 : ans);
+    }    
+}

--- a/week10/5719_거의 최단 경로/MayoneJY.java
+++ b/week10/5719_거의 최단 경로/MayoneJY.java
@@ -1,0 +1,129 @@
+
+import java.io.*;
+import java.util.*;
+
+public class MayoneJY {
+    public static int N, M, S, E;
+    static Map<Integer, Node>[] map;
+    
+    static class Node{
+        int s, e, dis;
+        Node(int s, int e, int dis){
+            this.s = s;
+            this.e = e;
+            this.dis = dis;
+        }
+    }
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        while (true) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            N = Integer.parseInt(st.nextToken());
+            M = Integer.parseInt(st.nextToken());
+            if(N == 0 && M == 0)
+                break;
+            st = new StringTokenizer(br.readLine());
+            S = Integer.parseInt(st.nextToken());
+            E = Integer.parseInt(st.nextToken());
+            map = new HashMap[N];
+            for(int i = 0; i < N; i++){
+                map[i] = new HashMap<>();
+            }
+            for(int m = 0; m < M; m++){
+                st = new StringTokenizer(br.readLine());
+                int s = Integer.parseInt(st.nextToken());
+                Integer e = Integer.parseInt(st.nextToken());
+                int d = Integer.parseInt(st.nextToken());
+
+                map[s].put(e, new Node(s, e, d));
+            }
+            int result = bfs();
+            System.out.println(result);
+        }
+    }
+
+    static int bfs(){
+        PriorityQueue<Node> q = new PriorityQueue<>((o1, o2) -> o1.dis - o2.dis);
+        int min = -1;
+        int count = 0;
+        boolean deleted = false;
+        Map<Integer, Integer> m = new HashMap<>();
+
+        breakout:
+        while (true) {
+            boolean[] result = new boolean[N];
+            int[][] prev = new int[N][2];
+            int[] dist = new int[N];
+            for(int i = 0; i < N; i++){
+                prev[i][0] = -1;
+                prev[i][1] = Integer.MAX_VALUE;
+                dist[i] = Integer.MAX_VALUE;
+            }
+            for(Integer key : map[S].keySet()){
+                Node n = map[S].get(key);
+                q.add(new Node(n.s, n.e, n.dis));
+            }
+            while (!q.isEmpty()) {
+                Node now = q.poll();
+                if(now.e == E){
+                    if(deleted){
+                        count++;
+                        min = now.dis;
+                        q.clear();
+                        break breakout;
+                    }
+                    if(prev[now.e][0] == -1 || prev[now.e][1] >= now.dis){
+                        prev[now.e][0] = now.s;
+                        prev[now.e][1] = now.dis;
+                    }
+                    if(min == -1){
+                        count++;
+                        min = now.dis;
+                        
+                        int cInt = E;
+                        while(cInt != S){
+                            int temp = cInt;
+                            cInt = prev[cInt][0];
+                            m.put(cInt, temp);
+                        }
+                    }
+                    else if(min == now.dis){
+                        int cInt = E;
+                        while(cInt != S){
+                            int temp = cInt;
+                            cInt = prev[cInt][0];
+                            m.put(cInt, temp);
+                        }
+                    }
+                    else if(min != now.dis){
+                        // count++;
+                        // min = now.dis;
+                        for(int mS : m.keySet()){
+                            map[mS].remove(m.get(mS));
+                        }
+                        deleted = true;
+                        m = null;
+                        q.clear();
+                        continue breakout;
+                    }
+                }
+
+                if(prev[now.e][0] == -1 || prev[now.e][1] >= now.dis){
+                    prev[now.e][0] = now.s;
+                    prev[now.e][1] = now.dis;
+                    for(Integer key : map[now.e].keySet()){
+                        if(!result[now.e]){
+                            Node next = map[now.e].get(key);
+                            Node newNode = new Node(next.s, next.e, now.dis + next.dis);
+                            q.add(newNode);
+                        }    
+                    }
+                }
+            }
+
+            if(q.isEmpty())
+                break;
+        }
+        return (count <= 1)?-1:min;
+    }
+}


### PR DESCRIPTION
## 🔗 문제 링크

[📌 BOJ 1806 - 부분합](https://www.acmicpc.net/problem/1806)

---

## 🧠 사용한 알고리즘 / 자료구조

- `투 포인터`

---

## 📝 간단한 풀이 설명

> 💡 **아이디어 요약**

- 연속된 부분 수열의 합이 `S` 이상이 되는 최소 길이를 구하는 문제
- 투 포인터를 사용하여 현재 구간의 합을 유지하면서 탐색
- 구간 합이 `S` 이상이 될 때마다 최소 길이 갱신
- 왼쪽 포인터를 옮겨가며 조건을 만족하는 가장 짧은 구간을 찾음

> 📈 **핵심 포인트**
- 단순 브루트포스로 풀면 `O(N^2)` → 시간 초과
- 투 포인터 기법을 쓰면 `O(N)`에 해결 가능
- while문으로 오른쪽 포인터를 움직이며 합을 늘리고, 조건 만족 시 왼쪽 포인터를 줄여가며 최적화

---

## 🧩 기타 참고사항 (Optional)

---

## 🔗 문제 링크

[📌 BOJ 5719 - 거의 최단 경로](https://www.acmicpc.net/problem/5719)

---

## 🧠 사용한 알고리즘 / 자료구조

- `다익스트라 (Dijkstra)`
- `간선 제거`

---

## 📝 간단한 풀이 설명

> 💡 **아이디어 요약**

1. 1차 다익스트라로 `S → E`의 최단거리 `dist[E]`와, 각 정점에 대해 “최단경로 상 직전 정점들(부모들)”을 저장한다.
2. 역추적(`E`에서 시작해 부모들을 타고 올라감)으로 **최단경로에 포함된 모든 간선(u → v)**을 수집한다.
3. 수집된 간선들을 그래프에서 제거한다.
4. 2차 다익스트라를 수행해 새로 얻은 `min`이 거의 최단 경로. 없으면 -1.

> 📈 **핵심 포인트**
- “최단경로에 포함된 모든 간선”을 제거해야 한다. 최단경로가 여러 개일 수 있으므로 **부모 리스트(여러 부모)**를 저장해서 역추적해야 한다.

---

## 🧩 기타 참고사항 (Optional)
알고보니 아직 풀지 못 했던 문제. 당일날 풀기위해 노력했지만 한 번 채점 하는데 30분 이상이 걸려 미완성으로 제출.

---

## 🔗 문제 링크

[📌 BOJ 16234 - 인구 이동](https://www.acmicpc.net/problem/16234)

---

## 🧠 사용한 알고리즘 / 자료구조

- `BFS, 시뮬레이션`

---

## 📝 간단한 풀이 설명

> 💡 **아이디어 요약**

- 매 “하루”에 대해, 각 칸을 아직 방문하지 않았다면 BFS로 상하좌우를 확장하며 인구 차이가 `[L, R]` 범위에 드는 국가들을 하나의 연합으로 묶는다.
- 연합의 총 인구와 칸 수를 모아 평균값(내림) 으로 갱신한다.
- 하루 동안 하나라도 국경이 열렸으면 인구 재분배가 일어난 것으로 보고 `count++` 하고 다음 날을 시뮬레이션한다.
- 어떤 날에도 국경이 열리지 않으면 종료한다.

> 📈 **핵심 포인트**

---

## 🧩 기타 참고사항 (Optional)

---
