### PR TITLE
[MayoneJY] week12

### DIFF
--- a/week12/1941_소문난 칠공주/MayoneJY.java
+++ b/week12/1941_소문난 칠공주/MayoneJY.java
@@ -1,0 +1,87 @@
+import java.util.*;
+import java.io.*;
+
+public class MayoneJY {
+    static final int N = 5;
+    static final int MIN = 4;
+    static final int M = 7;
+    static int result = 0;
+    static char[] map = new char[N*N];
+    static List<Integer> pick = new ArrayList<>();
+    static int[] dx = {1, 0, -1, 0};
+    static int[] dy = {0, 1, 0, -1};
+
+    static class Node implements Comparable<Node> {
+        int y, x;
+        Node(int y, int x){
+            this.y = y;
+            this.x = x;
+        }
+
+        @Override
+        public int compareTo(Node o){
+            if (this.x != o.x) return Integer.compare(this.x, o.x);
+            return Integer.compare(this.y, o.y);
+        }
+    }
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int t = 0;
+        for(int i = 0; i < N; i++){
+            char[] str = br.readLine().toCharArray();
+            for(int j = 0; j < N; j++){
+                map[t++] = str[j];
+            }
+        }
+    
+        for(int i = 0; i < 25; i++){
+            pick.clear();
+            pick.add(i);
+            dfs(i+1, 1, map[i] == 'S'?1:0);
+        }
+        System.out.println(result);
+    }
+
+    public static void bfs(int y, int x){
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        q.add(new int[]{y, x});
+        boolean[][] visited = new boolean[N][N];
+        visited[y][x] = true;
+        int count = 0;
+
+        while(!q.isEmpty()){
+            int[] now = q.poll();
+            count++;
+            for(int i = 0; i < 4; i++){
+                int ny = now[0] + dy[i];
+                int nx = now[1] + dx[i];
+
+                if(ny >= 0 && nx >= 0 && ny < N && nx < N && !visited[ny][nx]){
+                    
+                    visited[ny][nx] = true;
+                    if(pick.contains(ny*5+nx)){
+                        q.add(new int[] {ny, nx});
+                    }
+                }
+            }
+        }
+        if(count == 7)
+            result++;
+    }
+
+    public static void dfs(int idx, int count, int sCount){
+        if(count == M){
+            if(sCount >= MIN){
+                bfs(pick.get(0)/5, pick.get(0)%5);
+            }
+            return;
+        }
+        if(count - sCount == 4)
+            return;
+        for(int i = idx; i < 25; i++){
+            pick.add(i);
+            dfs(i+1, count+1, map[i] == 'S'?sCount+1:sCount);
+            pick.remove(pick.size()-1);
+        }
+    }
+}

--- a/week12/20183_골목 대장 호석 - 효율성 2/MayoneJY.java
+++ b/week12/20183_골목 대장 호석 - 효율성 2/MayoneJY.java
@@ -1,0 +1,92 @@
+import java.io.*;
+import java.util.*;
+
+public class MayoneJY {
+    static int N, M, S, E;
+    static long max;
+    static Map<Integer, List<Edge>> edges = new HashMap<>();
+    static class Edge{
+        int v;
+        long w, m = 0;
+        Edge(int v, long w){
+            this.v = v;
+            this.w = w;
+        }
+        Edge(int v, long w, long m){
+            this.v = v;
+            this.w = w;
+            this.m = m;
+        }
+    }
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        S = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+        max = Long.parseLong(st.nextToken());
+        
+        for(int i = 0; i < M; i++){
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            long v = Long.parseLong(st.nextToken());
+            edges.putIfAbsent(s, new ArrayList<>());
+            edges.putIfAbsent(e, new ArrayList<>());
+
+            edges.get(s).add(new Edge(e, v));
+            edges.get(e).add(new Edge(s, v));
+        }
+
+        bfs();
+    }
+
+    static void bfs(){
+        PriorityQueue<Edge> pq = new PriorityQueue<>((o1, o2) -> {
+            if(o1.m != o2.m)
+                return Long.compare(o1.m, o2.m);
+            return Long.compare(o1.w, o2.w);
+        });
+
+        long[] visited = new long[N+1];
+        long[] visitedMax = new long[N+1];
+        Arrays.fill(visited, Long.MAX_VALUE);
+        Arrays.fill(visitedMax, Long.MAX_VALUE);
+        visited[S] = 0;
+        visitedMax[S] = 0;
+        pq.add(new Edge(S, 0));
+        long result = Long.MAX_VALUE;
+        while (!pq.isEmpty()) {
+            Edge now = pq.poll();
+
+            if(now.m >= result)
+                continue;
+            if(now.v == E){
+                result = now.m;
+                // break;
+            }
+
+            if(visited[now.v] < now.w) continue;
+
+            for(Edge e: edges.get(now.v)){
+                long mm = Math.max(now.m, e.w);
+                if(now.w + e.w <= max && visitedMax[e.v] > mm){
+                    visited[e.v] = now.w + e.w;
+                    visitedMax[e.v] = mm;
+                    pq.add(new Edge(e.v, visited[e.v], mm));
+                }
+            }
+        }
+        // while (!pq.isEmpty()) {
+        //     Edge now = pq.poll();
+        //     if(now.v == E){
+        //         result = Math.min(result, now.m);
+        //     }
+        // }
+        if(result == Long.MAX_VALUE)
+            System.out.println(-1);
+        else
+            System.out.println(result);
+    }
+}

--- a/week12/2531_회전 초밥/MayoneJY.java
+++ b/week12/2531_회전 초밥/MayoneJY.java
@@ -1,0 +1,56 @@
+import java.io.*;
+import java.util.*;
+
+public class MayoneJY {
+    static int N, D, K, C;
+    static int[] susi;
+    static List<Integer> selectSusi = new LinkedList<>();
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        D = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        susi = new int[K];
+
+        int count = 0;
+        int max = 0;
+        int j = 0;
+        for(int i = 0; i < K-1; i++){
+            int t = Integer.parseInt(br.readLine());
+            if(i < K){
+                if(!selectSusi.contains(t))
+                    count++;
+                susi[i] = t;
+                selectSusi.add(t);
+            }
+        }
+        int i = 0;
+        for(i = 0; i < N; i++){
+            if(N - i + 1 <= K){
+                if(!selectSusi.contains(susi[j]))
+                    count++;
+                selectSusi.add(susi[j++]);
+            }
+            else{
+                int t = Integer.parseInt(br.readLine());
+                if(!selectSusi.contains(t))
+                    count++;
+                selectSusi.add(t);
+            }
+            if(!selectSusi.contains(C))
+                max = Math.max(max, count + 1);
+            else
+                max = Math.max(max, count);
+            
+            if(max == K + 1)
+                break;
+
+            if(!selectSusi.contains(selectSusi.remove(0)))
+                count--;
+        }
+        System.out.println(max);
+    }
+}

--- a/week12/6497_전력난/MayoneJY.java
+++ b/week12/6497_전력난/MayoneJY.java
@@ -1,0 +1,66 @@
+import java.io.*;
+import java.util.*;
+
+public class MayoneJY {
+    static int N, M;
+    static PriorityQueue<Edge> pq = new PriorityQueue<>((o1, o2) -> Integer.compare(o1.w, o2.w));
+    static int[] parent;
+    static int max;
+    static class Edge{
+        int s, v, w;
+        Edge(int s, int v, int w){
+            this.s = s;
+            this.v = v;
+            this.w = w;
+        }
+    }
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        while (true) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            N = Integer.parseInt(st.nextToken());
+            M = Integer.parseInt(st.nextToken());
+
+            if(N == 0 && M == 0) return;
+            max = 0;
+            parent = new int[N];
+            for(int i = 0; i < N; i++)
+                parent[i] = i;
+
+            for(int i = 0; i < M; i++){
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                int c = Integer.parseInt(st.nextToken());
+                max += c;
+                pq.add(new Edge(a, b, c));
+            }
+    
+            int result = 0;
+            while (!pq.isEmpty()) {
+                Edge now = pq.poll();
+
+                if(find(now.s) == find(now.v)) continue;
+
+                union(now.s, now.v);
+                result += now.w;
+                
+            }
+
+            System.out.println(max - result);
+        }
+    }
+
+    public static int find(int a){
+        if (parent[a] == a) return a;
+        return parent[a] = find(parent[a]);
+    }
+
+    public static void union(int a, int b){
+        a = find(a);
+        b = find(b);
+        if(a != b){
+            parent[b] = a;
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 문제 링크

[📌 BOJ 1941 - 소문난 칠공주](https://www.acmicpc.net/problem/1941)

---

## 🧠 사용한 알고리즘 / 자료구조

- `DFS`, `BFS`

---

## 📝 간단한 풀이 설명

> 💡 **아이디어 요약**

- DFS로 7개를 뽑은 뒤, BFS로 서로 인접했는지 검사하는 방식.

> 📈 **핵심 포인트**
- DFS와 BFS를 같이 사용하는 것이 핵심

---

## 🧩 기타 참고사항 (Optional)

---

## 🔗 문제 링크

[📌 BOJ 20183 - 골목 대장 호석 - 효율성 2](https://www.acmicpc.net/problem/20183)

---

## 🧠 사용한 알고리즘 / 자료구조

- `다익스트라`

---

## 📝 간단한 풀이 설명

> 💡 **아이디어 요약**

- 우선순위 큐 다익스트라를 사용하는데, 우선순위를 먼저 골목의 요금의 최댓값의 최솟값이 우선순위 두 번째로 최소 거리로 한다.

> 📈 **핵심 포인트**
- 우선순위를 결정하는 것이 핵심

---

## 🧩 기타 참고사항 (Optional)

---

## 🔗 문제 링크

[📌 BOJ 6497 - 전력난](https://www.acmicpc.net/problem/6497)

---

## 🧠 사용한 알고리즘 / 자료구조

- `유니온 파인드`, `크루스칼`

---

## 📝 간단한 풀이 설명

> 💡 **아이디어 요약**

- 크루스칼로 최소 신장 트리를 구성한 뒤 모든 간선 값에서 빼준다.

> 📈 **핵심 포인트**

---

## 🧩 기타 참고사항 (Optional)
---

## 🔗 문제 링크

[📌 BOJ 2531 - 회전 초밥](https://www.acmicpc.net/problem/2531)

---

## 🧠 사용한 알고리즘 / 자료구조

- `슬라이딩 윈도우`

---

## 📝 간단한 풀이 설명

> 💡 **아이디어 요약**

- 슬라이딩 윈도우를 이용해 카운팅을 한다.

> 📈 **핵심 포인트**

---

## 🧩 기타 참고사항 (Optional)

